### PR TITLE
Add Gather for Cube Depth Texture Array

### DIFF
--- a/shader-texture-functions.md
+++ b/shader-texture-functions.md
@@ -654,6 +654,14 @@ A gather returns 4 samples of a specified channel (r,g,b,a) for bilinear interpo
 | MSL     | `Tv depthcube.gather(sampler s, float3 coord)`                                                                                                        |          |
 | SPIR-V  | [`OpImageGather <sampled-image> <coord> <component> [image-operands...]`](https://www.khronos.org/registry/spir-v/specs/1.0/SPIRV.html#OpImageGather) |          |
 
+### Gather - Cube Depth Texture Array
+
+| Backend | Function                                                                                                                                              | Comments |
+|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| HLSL    | [`TextureCube.Gather(sampler s, float4 coord)`](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/texturecube-gather)                       |          |
+| MSL     | `Tv depthcube_array.gather(sampler s, float3 coord, uint array)`                                                                                      |          |
+| SPIR-V  | [`OpImageGather <sampled-image> <coord> <component> [image-operands...]`](https://www.khronos.org/registry/spir-v/specs/1.0/SPIRV.html#OpImageGather) |          |
+
 ## Gather Compare
 
 ### Gather Compare - 2D Depth Texture


### PR DESCRIPTION
This seems to be missing from the table.
It's the 4th gather variant for depth textures.
The other three are for 2D, 2D Array, and Cube.